### PR TITLE
Allow nested directories and names starting with '-'

### DIFF
--- a/functions/mkdir-cd.fish
+++ b/functions/mkdir-cd.fish
@@ -1,3 +1,3 @@
 function mkdir-cd
-    mkdir $argv && cd $argv
+    mkdir -p -- $argv && cd -- $argv
 end


### PR DESCRIPTION
1. The -p flag created intermediate directories for nested directories.
2. The '--' piece lets the command know the there are no more options after it. Hence allowing us to create directories starting with '-'.

Usage: `mkdir -/a/b`