### PR TITLE
Remove dollar sign from installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Functions for the [Fish Shell](https://fishshell.com), making common tasks more 
 
 ```sh
 # Backup your old ~/.config/fish first, then:
-$ git clone https://git.sr.ht/~razzi/fish-functions ~/.config/fish
+git clone https://git.sr.ht/~razzi/fish-functions ~/.config/fish
 ```
 
 In previous versions, other fish config including abbrs were included as well.


### PR DESCRIPTION
dollar sign gets copied with the snippet which disables it from working when pasted into shell. Without it copy paste works.