### PR TITLE
fix: update wifi-network-name.fish

### DIFF
--- a/functions/wifi-network-name.fish
+++ b/functions/wifi-network-name.fish
@@ -1,3 +1,3 @@
 function wifi-network-name
-    /System/Library/PrivateFrameworks/Apple80211.framework/Versions/Current/Resources/airport -I | awk '/ SSID/ {print substr($0, index($0, $2))}'
+    networksetup -getairportnetwork en0 | awk '{print $4}'
 end


### PR DESCRIPTION
airport command line tool is deprecated:
```
WARNING: The airport command line tool is deprecated and will be removed in a future release.
For diagnosing Wi-Fi related issues, use the Wireless Diagnostics app or wdutil command line tool.
```